### PR TITLE
Add missing devDependency tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "buffer-concat": "~0.0.1"
   },
   "devDependencies": {
+    "tap": "10.3.1",
     "tape": "~0.2.2"
   },
   "bin": {


### PR DESCRIPTION
Without the `tap` devDependency the tests are not run at all:
```shell
$ npm test

> replace3@0.6.1 test /home/sweet/version/github.com/replace3.git
> tap test

sh: 1: tap: not found
npm ERR! Test failed.  See above for more details.
```