### PR TITLE
Only start handleStack in --async mode

### DIFF
--- a/replace.js
+++ b/replace.js
@@ -95,7 +95,9 @@ module.exports = function(options) {
         })
       }
     }
-    setInterval(handleStack, 0)
+	if (options.async) {
+		setInterval(handleStack, 0)
+	}
 
     if (!options.color) {
         options.color = "cyan";


### PR DESCRIPTION
On Windows 10, node process does not exit. This patch fixes the sync mode. In async mode, problem still exists.